### PR TITLE
generalized paths across OS and root directories

### DIFF
--- a/ChartNuclides_Dillmann_Version5.py
+++ b/ChartNuclides_Dillmann_Version5.py
@@ -2,12 +2,18 @@
 
 import numpy as np
 import matplotlib.pyplot as plt
+import os
 
 def MOELLER():
-    filename1_MO = "C:\Users\Stephanie_2\Documents\GitHub\TRIUMF-Bn-Chart\Text_Files\ChartNuclides_DataTable_P_MOELLER.txt"
-    filename2_MO = "C:\Users\Stephanie_2\Documents\GitHub\TRIUMF-Bn-Chart\Text_Files\ChartNuclides_DataTable_ELE_MOELLER.txt"
-    filename3_MO = "C:\Users\Stephanie_2\Documents\GitHub\TRIUMF-Bn-Chart\Text_Files\ChartNuclides_DataTable1.txt" 
-    filename4_MO = "C:\Users\Stephanie_2\Documents\GitHub\TRIUMF-Bn-Chart\Text_Files\N_Z_stable.txt"
+    if os.name == "nt":
+        dirDelim = "\\"
+    else:
+        dirDelim = "/";
+
+    filename1_MO = os.getcwd()+dirDelim + "Text_Files" + dirDelim + "ChartNuclides_DataTable_P_MOELLER.txt"
+    filename2_MO = os.getcwd()+dirDelim + "Text_Files" + dirDelim + "ChartNuclides_DataTable_ELE_MOELLER.txt"
+    filename3_MO = os.getcwd()+dirDelim + "Text_Files" + dirDelim + "ChartNuclides_DataTable1.txt" 
+    filename4_MO = os.getcwd()+dirDelim + "Text_Files" + dirDelim + "N_Z_stable.txt"
 
     #assigns one column of data in the text files to various specific arrays
     N_P,Z_P,P1n,P2n,P3n = np.loadtxt(filename1_MO,skiprows=1,unpack=True)
@@ -335,26 +341,30 @@ def MOELLER():
 #------------------------------------------------------------------------------------------------------------
 
 def main():
-    
+
     choice_user = 0
     choice_user = input("Enter 1 to display the experimental version; Enter 2 to display the theoretical version: ")
+    if os.name == "nt":
+        dirDelim = "\\"
+    else:
+        dirDelim = "/";
 
     if choice_user == 2:
         MOELLER()
     else:
         #reads in values from text files and stores all of the data columns into arrays
-        filename1 = "C:\Users\Stephanie_2\Documents\GitHub\TRIUMF-Bn-Chart\Text_Files\ChartNuclides_DataTable1.txt" 
-        filename2 = "C:\Users\Stephanie_2\Documents\GitHub\TRIUMF-Bn-Chart\Text_Files\N_Z_stable.txt"
+        filename1 = os.getcwd()+dirDelim + "Text_Files" + dirDelim + "ChartNuclides_DataTable1.txt" 
+        filename2 = os.getcwd()+dirDelim + "Text_Files" + dirDelim + "N_Z_stable.txt"
         
-        filename3 = "C:\Users\Stephanie_2\Documents\GitHub\TRIUMF-Bn-Chart\Text_Files\ChartNuclides_DataTable_Qbn.txt" 
-        filename4 = "C:\Users\Stephanie_2\Documents\GitHub\TRIUMF-Bn-Chart\Text_Files\ChartNuclides_DataTable_Qb2n.txt"
-        filename5 = "C:\Users\Stephanie_2\Documents\GitHub\TRIUMF-Bn-Chart\Text_Files\ChartNuclides_DataTable_Qb3n.txt"
-        filename6 = "C:\Users\Stephanie_2\Documents\GitHub\TRIUMF-Bn-Chart\Text_Files\ChartNuclides_DataTable_Qb4n.txt"
+        filename3 = os.getcwd()+dirDelim + "Text_Files" + dirDelim + "ChartNuclides_DataTable_Qbn.txt" 
+        filename4 = os.getcwd()+dirDelim + "Text_Files" + dirDelim + "ChartNuclides_DataTable_Qb2n.txt"
+        filename5 = os.getcwd()+dirDelim + "Text_Files" + dirDelim + "ChartNuclides_DataTable_Qb3n.txt"
+        filename6 = os.getcwd()+dirDelim + "Text_Files" + dirDelim + "ChartNuclides_DataTable_Qb4n.txt"
 
-        filename7 = "C:\Users\Stephanie_2\Documents\GitHub\TRIUMF-Bn-Chart\Text_Files\ChartNuclides_DataTable_P_ENSDF.txt"
-        filename8 = "C:\Users\Stephanie_2\Documents\GitHub\TRIUMF-Bn-Chart\Text_Files\ChartNuclides_DataTable_ELE_ENSDF.txt"
-        filename9 = "C:\Users\Stephanie_2\Documents\GitHub\TRIUMF-Bn-Chart\Text_Files\ChartNuclides_DataTable_iso1_ENSDF.txt"
-        filename10 = "C:\Users\Stephanie_2\Documents\GitHub\TRIUMF-Bn-Chart\Text_Files\ChartNuclides_DataTable_iso2_ENSDF.txt"
+        filename7 = os.getcwd()+dirDelim + "Text_Files" + dirDelim + "ChartNuclides_DataTable_P_ENSDF.txt"
+        filename8 = os.getcwd()+dirDelim + "Text_Files" + dirDelim + "ChartNuclides_DataTable_ELE_ENSDF.txt"
+        filename9 = os.getcwd()+dirDelim + "Text_Files" + dirDelim + "ChartNuclides_DataTable_iso1_ENSDF.txt"
+        filename10 = os.getcwd()+dirDelim + "Text_Files" + dirDelim + "ChartNuclides_DataTable_iso2_ENSDF.txt"
 
         N,Z,bn,b2n = np.loadtxt(filename1,skiprows=1,unpack=True)
         s1 = len(N)


### PR DESCRIPTION
Hi Stephanie,

Great work!  This PR is what I had to do to be able to start running the code on my machine.  It does two new things:
- No more hard-coded paths - I get the current working directory from `os.getcwd()`.  This does however expect that the program was launched from the root directory of the project.
- In microsoft's infinite wisdom, they apparently use the reverse \ for delimiting directories WRT unix.  I use `os.name == "nt"` to decide if I'm on a windows machine, whereupon I use their delimiter, or else just / everywhere else.  I don't actually have a windows box, so please check if this actually works there!

You can certainly solve these problems better than a giant Python noob like me, so this may just be an interim hack until you have time to look at it yourself - but it lets us both (I hope) run the code for now.  Let me know!
